### PR TITLE
fix: Use nginx user (UID 101) for container permissions

### DIFF
--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -21,6 +21,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
+      attestations: write
 
     steps:
       - name: Checkout repository
@@ -66,6 +68,7 @@ jobs:
             type=sha,prefix=
 
       - name: Build and push image
+        id: push
         uses: docker/build-push-action@v5
         with:
           context: .
@@ -78,8 +81,8 @@ jobs:
 
       - name: Generate artifact attestation
         if: github.event_name != 'pull_request'
-        uses: actions/attest-build-provenance@v1
+        uses: actions/attest-build-provenance@v2
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          subject-digest: ${{ steps.build-push.outputs.digest }}
+          subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,16 +24,16 @@ COPY nginx.conf /etc/nginx/conf.d/default.conf
 # Copy built assets from build stage
 COPY --from=build /app/dist /usr/share/nginx/html
 
-# Create non-root user
-RUN adduser -D -g '' appuser && \
-    chown -R appuser:appuser /usr/share/nginx/html && \
-    chown -R appuser:appuser /var/cache/nginx && \
-    chown -R appuser:appuser /var/log/nginx && \
+# Configure permissions for nginx user (UID 101)
+# This ensures the container can run as non-root with runAsUser: 101
+RUN chown -R nginx:nginx /usr/share/nginx/html && \
+    chown -R nginx:nginx /var/cache/nginx && \
+    chown -R nginx:nginx /var/log/nginx && \
     touch /var/run/nginx.pid && \
-    chown -R appuser:appuser /var/run/nginx.pid
+    chown -R nginx:nginx /var/run/nginx.pid
 
-# Use non-root user
-USER appuser
+# Run as nginx user (UID 101)
+USER nginx
 
 # Expose port
 EXPOSE 8080


### PR DESCRIPTION
## Problem

The container fails to start with:

```
nginx: [emerg] mkdir() "/var/cache/nginx/client_temp" failed (13: Permission denied)
```

## Root Cause

- Dockerfile created `appuser` without explicit UID → assigned ~1000
- Kubernetes deployment specifies `runAsUser: 101`
- UID mismatch → nginx cannot write to `/var/cache/nginx/`

## Solution

Use the built-in `nginx` user (UID 101) instead of creating a custom user:

```dockerfile
# Before (broken)
RUN adduser -D -g '' appuser && \
    chown -R appuser:appuser ...
USER appuser

# After (fixed)
RUN chown -R nginx:nginx ...
USER nginx
```

## Testing

The GitHub Actions workflow will build and push a new image. After merge, restart the landing page pod:

```bash
kubectl rollout restart deployment/landingpage -n platform-apps
```

## Related

- Fixes digiorg/core#24
