### PR TITLE
fix: Remove PKCE and add fallback login for HTTP environments

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -24,7 +24,7 @@ export async function initAuth(): Promise<boolean> {
       onLoad: 'check-sso',
       silentCheckSsoRedirectUri: `${window.location.origin}/silent-check-sso.html`,
       checkLoginIframe: false, // Disabled due to modern browser restrictions
-      pkceMethod: 'S256'
+      // pkceMethod: 'S256' — disabled: Web Crypto API requires HTTPS (not available on http://)
     });
 
     authInitialized = true;
@@ -45,23 +45,26 @@ export async function initAuth(): Promise<boolean> {
 }
 
 /**
- * Trigger login flow
- * Throws error if Keycloak is not available
+ * Trigger login flow.
+ * Uses Keycloak JS adapter if initialized, otherwise falls back to a direct
+ * OIDC redirect. The fallback works without Web Crypto API (HTTP environments).
  */
 export function login(): void {
-  if (!keycloakInstance) {
-    const errorMsg = 'Authentication service is not available. Please try again later.';
-    console.error(errorMsg);
-    throw new Error(errorMsg);
+  if (keycloakInstance && authInitialized) {
+    keycloakInstance.login();
+  } else {
+    // Fallback: direct redirect to Keycloak authorization endpoint.
+    // Does not require PKCE / Web Crypto API — works over plain HTTP.
+    const config = getConfig();
+    const params = new URLSearchParams({
+      client_id: config.keycloak.clientId,
+      redirect_uri: window.location.href,
+      response_type: 'code',
+      scope: 'openid',
+    });
+    window.location.href =
+      `${config.keycloak.url}/realms/${config.keycloak.realm}/protocol/openid-connect/auth?${params}`;
   }
-  
-  if (!authInitialized) {
-    const errorMsg = authError || 'Authentication service failed to initialize.';
-    console.error(errorMsg);
-    throw new Error(errorMsg);
-  }
-  
-  keycloakInstance.login();
 }
 
 /**

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -35,7 +35,7 @@ export function renderApp(services: PlatformService[], theme: Theme): void {
 /**
  * Render header with logo, user info, and theme toggle
  */
-function renderHeader(authenticated: boolean, username?: string, theme?: Theme, authAvailable?: boolean): string {
+function renderHeader(authenticated: boolean, username?: string, theme?: Theme, _authAvailable?: boolean): string {
   const currentTheme = theme || getTheme();
   
   return `
@@ -60,7 +60,7 @@ function renderHeader(authenticated: boolean, username?: string, theme?: Theme, 
             </button>
           </div>
         ` : `
-          <button class="btn btn-primary" id="login-btn" ${!authAvailable ? 'disabled title="Authentication service unavailable"' : ''}>
+          <button class="btn btn-primary" id="login-btn">
             ${getIcon('log-in')}
             <span>Login</span>
           </button>
@@ -172,7 +172,7 @@ function renderFooter(): string {
 /**
  * Attach event listeners
  */
-function attachEventListeners(authAvailable: boolean): void {
+function attachEventListeners(_authAvailable: boolean): void {
   // Theme toggle
   const themeToggle = document.getElementById('theme-toggle');
   themeToggle?.addEventListener('click', () => {
@@ -183,20 +183,10 @@ function attachEventListeners(authAvailable: boolean): void {
     }
   });
 
-  // Login button
+  // Login button — always clickable; login() handles fallback internally
   const loginBtn = document.getElementById('login-btn');
   loginBtn?.addEventListener('click', () => {
-    if (!authAvailable) {
-      alert('Authentication service is currently unavailable. Please try again later.');
-      return;
-    }
-    
-    try {
-      login();
-    } catch (error) {
-      const message = error instanceof Error ? error.message : 'Login failed';
-      alert(message);
-    }
+    login();
   });
 
   // Logout button


### PR DESCRIPTION
Fixes #10

## Changes

### src/auth.ts
- Removed `pkceMethod: 'S256'` — Web Crypto API is only available in secure contexts (HTTPS). On `http://digiorg.local` the Keycloak adapter threw `Error: Web Crypto API is not available` and failed to initialize.
- Added direct OIDC redirect fallback in `login()`: when the Keycloak adapter is unavailable, redirects directly to the Keycloak authorization endpoint without PKCE. Works over plain HTTP.

### src/ui.ts
- Login button is now **always enabled** — `login()` handles the fallback internally.

## Behavior After Fix

| Scenario | Before | After |
|----------|--------|-------|
| HTTP environment | Button disabled, error banner | Button clickable, fallback redirect to Keycloak |
| Keycloak init succeeds | Normal OIDC flow | Normal OIDC flow (unchanged) |
| Keycloak init fails | Broken | Direct redirect to KC login page |

## Note

PKCE (`S256`) should be re-enabled once HTTPS is configured on the cluster (Option B from issue #10).