### PR TITLE
fix: Detect insecure context, skip keycloak-js on HTTP, shrink error banner

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -7,12 +7,34 @@ let authInitialized = false;
 let authError: string | null = null;
 
 /**
- * Initialize Keycloak authentication
- * Uses silent SSO check for better UX
+ * Check if the browser is in a secure context (HTTPS or localhost).
+ * Web Crypto API (required by keycloak-js) is only available in secure contexts.
+ */
+function isSecureContext(): boolean {
+  return window.isSecureContext ||
+    window.location.hostname === 'localhost' ||
+    window.location.hostname === '127.0.0.1' ||
+    window.location.hostname === '[::1]';
+}
+
+/**
+ * Initialize Keycloak authentication.
+ * On insecure HTTP contexts, skips keycloak-js (Web Crypto unavailable)
+ * and falls back to direct OIDC redirect on login.
  */
 export async function initAuth(): Promise<boolean> {
   const config = getConfig();
-  
+
+  // keycloak-js requires Web Crypto API (for PKCE / token handling).
+  // Web Crypto is only available in secure contexts (HTTPS / localhost).
+  // On plain HTTP, skip init silently — login() will use direct redirect fallback.
+  if (!isSecureContext()) {
+    console.info('Insecure context (HTTP): skipping keycloak-js init, using direct login redirect.');
+    authInitialized = false;
+    authError = null; // Not an error — expected behaviour on HTTP
+    return false;
+  }
+
   keycloakInstance = new Keycloak({
     url: config.keycloak.url,
     realm: config.keycloak.realm,
@@ -23,15 +45,14 @@ export async function initAuth(): Promise<boolean> {
     const authenticated = await keycloakInstance.init({
       onLoad: 'check-sso',
       silentCheckSsoRedirectUri: `${window.location.origin}/silent-check-sso.html`,
-      checkLoginIframe: false, // Disabled due to modern browser restrictions
-      // pkceMethod: 'S256' — disabled: Web Crypto API requires HTTPS (not available on http://)
+      checkLoginIframe: false,
+      pkceMethod: 'S256' // Safe: only reached in secure contexts (HTTPS)
     });
 
     authInitialized = true;
     authError = null;
 
     if (authenticated) {
-      // Set up token refresh
       setupTokenRefresh();
     }
 

--- a/src/style.css
+++ b/src/style.css
@@ -521,13 +521,20 @@ body::before {
 .auth-error {
   display: flex;
   align-items: center;
-  gap: var(--spacing-sm);
-  padding: var(--spacing-sm) var(--spacing-md);
-  background: rgba(239, 83, 80, 0.1);
-  border: 1px solid rgba(239, 83, 80, 0.3);
+  gap: var(--spacing-xs);
+  padding: var(--spacing-xs) var(--spacing-sm);
+  background: rgba(239, 83, 80, 0.08);
+  border: 1px solid rgba(239, 83, 80, 0.25);
   border-radius: var(--radius-md);
-  font-size: var(--font-size-sm);
+  font-size: var(--font-size-xs);
   color: var(--color-error);
+  margin-bottom: var(--spacing-md);
+}
+
+.auth-error svg {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
 }
 
 /* Responsive */


### PR DESCRIPTION
Fixes #12

## Changes

### src/auth.ts

Added `isSecureContext()` check before keycloak-js initialization:

- **HTTP (insecure):** Skip keycloak-js entirely, set `authError = null` (no error banner), `login()` uses direct OIDC redirect without PKCE
- **HTTPS (secure):** Full keycloak-js init with `pkceMethod: S256` restored

```
http://digiorg.local  → skip init → no banner → login button → direct redirect
https://digiorg.local → full init → PKCE flow  → login button → keycloak-js
```

### src/style.css

Reduced `.auth-error` banner size:
- Smaller padding (`xs/sm` instead of `sm/md`)
- Smaller font (`xs` instead of `sm`)
- Icon constrained to `14x14px`
- Reduced background/border opacity
