### PR TITLE
feat: Update default config to HTTPS (supports core#27)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -4,9 +4,9 @@ import type { PlatformConfig } from './types';
  * Default configuration for local development
  */
 const defaultConfig: PlatformConfig = {
-  baseUrl: 'http://digiorg.local',
+  baseUrl: 'https://digiorg.local',
   keycloak: {
-    url: 'http://digiorg.local/keycloak',
+    url: 'https://digiorg.local/keycloak',
     realm: 'digiorg-core-platform',
     clientId: 'landingpage'
   },


### PR DESCRIPTION
Part of digiorg/core#27 (HTTPS/TLS via cert-manager).

Updates the default fallback config in `src/config.ts` to use `https://digiorg.local` instead of `http://`. The runtime config from the ConfigMap takes precedence, but this ensures the defaults are consistent with the HTTPS setup.