### PR TITLE
feat: Require auth for Backstage and Gitea tiles

### DIFF
--- a/public/services.json
+++ b/public/services.json
@@ -16,7 +16,7 @@
     "path": "/backstage",
     "icon": "code",
     "category": "developer",
-    "requiresAuth": false,
+    "requiresAuth": true,
     "displayOrder": 2
   },
   {
@@ -26,7 +26,7 @@
     "path": "/gitea",
     "icon": "git",
     "category": "developer",
-    "requiresAuth": false,
+    "requiresAuth": true,
     "displayOrder": 3
   },
   {

--- a/src/services.ts
+++ b/src/services.ts
@@ -24,7 +24,7 @@ const defaultServices: PlatformService[] = [
     path: '/backstage',
     icon: 'code',
     category: 'developer',
-    requiresAuth: false,
+    requiresAuth: true,
     displayOrder: 2
   },
   {
@@ -34,7 +34,7 @@ const defaultServices: PlatformService[] = [
     path: '/gitea',
     icon: 'git',
     category: 'developer',
-    requiresAuth: false,
+    requiresAuth: true,
     displayOrder: 3
   },
   {


### PR DESCRIPTION
Closes #16

Sets `requiresAuth: true` for the Backstage ("Components & Catalog") and Gitea ("Repositories & Pipelines") tiles.

## Changes

| Service | Before | After |
|---------|--------|-------|
| Components & Catalog (Backstage) | `requiresAuth: false` — always clickable | `requiresAuth: true` — locked when logged out |
| Repositories & Pipelines (Gitea) | `requiresAuth: false` — always clickable | `requiresAuth: true` — locked when logged out |

**Files changed:** `src/services.ts`, `public/services.json`

## Tile Behavior

| | Logged out | Logged in |
|-|-----------|----------|
| Identities & Access | ✅ | ✅ |
| Components & Catalog | 🔒 | ✅ |
| Repositories & Pipelines | 🔒 | ✅ |
| GitOps & Deployment | 🔒 | ✅ |
| Logging & Monitoring | 🔒 | ✅ |

Note: The Kubernetes ConfigMap in `core` repo is updated separately (PR in digiorg/core).