### PR TITLE
feat: Add NATS Messaging & Events tile to landing page

### DIFF
--- a/public/services.json
+++ b/public/services.json
@@ -48,5 +48,15 @@
     "category": "monitoring",
     "requiresAuth": true,
     "displayOrder": 5
+  },
+  {
+    "id": "nats",
+    "name": "Messaging & Events",
+    "description": "Event streaming and messaging infrastructure",
+    "path": "/nats",
+    "icon": "message",
+    "category": "messaging",
+    "requiresAuth": true,
+    "displayOrder": 6
   }
 ]

--- a/src/services.ts
+++ b/src/services.ts
@@ -56,6 +56,16 @@ const defaultServices: PlatformService[] = [
     category: 'monitoring',
     requiresAuth: true,
     displayOrder: 5
+  },
+  {
+    id: 'nats',
+    name: 'Messaging & Events',
+    description: 'Event streaming and messaging infrastructure',
+    path: '/nats',
+    icon: 'message',
+    category: 'messaging',
+    requiresAuth: true,
+    displayOrder: 6
   }
 ];
 


### PR DESCRIPTION
Part of digiorg/core#21

Adds the NATS "Messaging & Events" tile to the landing page.

- `src/services.ts`: Added NATS service (displayOrder: 6, requiresAuth: true)
- `public/services.json`: Same change in bundled fallback JSON

The tile is locked when the user is not logged in, consistent with ArgoCD and Grafana.