### PR TITLE
feat: Remove NATS tile from landing page

### DIFF
--- a/public/services.json
+++ b/public/services.json
@@ -48,15 +48,5 @@
     "category": "monitoring",
     "requiresAuth": true,
     "displayOrder": 5
-  },
-  {
-    "id": "nats",
-    "name": "Messaging & Events",
-    "description": "Event streaming and messaging infrastructure",
-    "path": "/nats",
-    "icon": "message",
-    "category": "messaging",
-    "requiresAuth": true,
-    "displayOrder": 6
   }
 ]

--- a/src/services.ts
+++ b/src/services.ts
@@ -56,16 +56,6 @@ const defaultServices: PlatformService[] = [
     category: 'monitoring',
     requiresAuth: true,
     displayOrder: 5
-  },
-  {
-    id: 'nats',
-    name: 'Messaging & Events',
-    description: 'Event streaming and messaging infrastructure',
-    path: '/nats',
-    icon: 'message',
-    category: 'messaging',
-    requiresAuth: true,
-    displayOrder: 6
   }
 ];
 


### PR DESCRIPTION
Part of digiorg/core#66

NATS Surveyor is a Prometheus metrics exporter, not a web UI. NATS monitoring is now integrated into Grafana (dashboards auto-provisioned via ConfigMap).

Removes the "Messaging & Events" tile from `src/services.ts` and `public/services.json`.