### PR TITLE
feat(jaeger): Add tracing icon, observability category and default service (#20)

### DIFF
--- a/src/icons.ts
+++ b/src/icons.ts
@@ -69,7 +69,21 @@ const icons: Record<string, string> = {
   activity: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
     <polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/>
   </svg>`,
-  
+
+  tracing: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <line x1="3" y1="12" x2="21" y2="12"/>
+  <line x1="5" y1="7" x2="14" y2="7"/>
+  <circle cx="5" cy="7" r="1.5" fill="currentColor" stroke="none"/>
+  <circle cx="14" cy="7" r="1.5" fill="currentColor" stroke="none"/>
+  <line x1="8" y1="17" x2="19" y2="17"/>
+  <circle cx="8" cy="17" r="1.5" fill="currentColor" stroke="none"/>
+  <circle cx="19" cy="17" r="1.5" fill="currentColor" stroke="none"/>
+  <line x1="5" y1="12" x2="5" y2="7" stroke-dasharray="2 2"/>
+  <line x1="14" y1="12" x2="14" y2="7" stroke-dasharray="2 2"/>
+  <line x1="8" y1="12" x2="8" y2="17" stroke-dasharray="2 2"/>
+  <line x1="19" y1="12" x2="19" y2="17" stroke-dasharray="2 2"/>
+</svg>`,
+
   // Developer
   code: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
     <polyline points="16 18 22 12 16 6"/>

--- a/src/services.ts
+++ b/src/services.ts
@@ -56,6 +56,16 @@ const defaultServices: PlatformService[] = [
     category: 'monitoring',
     requiresAuth: true,
     displayOrder: 5
+  },
+  {
+    id: 'jaeger',
+    name: 'Distributed Tracing',
+    description: 'Trace requests across services',
+    path: '/jaeger',
+    icon: 'tracing',
+    category: 'observability',
+    requiresAuth: true,
+    displayOrder: 6
   }
 ];
 
@@ -113,6 +123,7 @@ export function getCategoryName(category: ServiceCategory | string): string {
     security: 'Security',
     deployment: 'Deployment',
     monitoring: 'Observability',
+    observability: 'Observability',
     developer: 'Developer',
     data: 'Data',
     messaging: 'Messaging',

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,10 +28,11 @@ export interface PlatformService {
 /**
  * Service categories for grouping
  */
-export type ServiceCategory = 
+export type ServiceCategory =
   | 'security'
   | 'deployment'
   | 'monitoring'
+  | 'observability'
   | 'developer'
   | 'data'
   | 'messaging'


### PR DESCRIPTION
## Summary

Closes #20 — adds Jaeger support to the landing page frontend.

These changes ensure the Jaeger service card (registered in [digiorg/core#79](https://github.com/digiorg/core/pull/79)) renders correctly.

## Changes

### `src/icons.ts`
- Added `tracing` SVG icon (Gantt-style span visualization)

### `src/types.ts`
- Added `'observability'` to `ServiceCategory` union type

### `src/services.ts`
- Added `observability: 'Observability'` to `getCategoryName` mapping
- Added Jaeger (`'Distributed Tracing'`) to `defaultServices` fallback list

## Acceptance Criteria
- [x] Jaeger card renders with tracing icon
- [x] Category badge shows `Observability`
- [x] TypeScript compiles cleanly
- [x] Jaeger present in API-down fallback

Depends on: digiorg/core#79