### PR TITLE
feat(sonarqube): add code-quality icon, devsecops category and default service

### DIFF
--- a/src/icons.ts
+++ b/src/icons.ts
@@ -70,6 +70,13 @@ const icons: Record<string, string> = {
     <polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/>
   </svg>`,
 
+  // Code Quality
+  'code-quality': `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="10.5" cy="10.5" r="7.5"/>
+  <line x1="21" y1="21" x2="15.8" y2="15.8"/>
+  <polyline points="7.5 10.5 9.5 12.5 13.5 8.5"/>
+</svg>`,
+
   tracing: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
   <line x1="3" y1="12" x2="21" y2="12"/>
   <line x1="5" y1="7" x2="14" y2="7"/>

--- a/src/services.ts
+++ b/src/services.ts
@@ -66,6 +66,16 @@ const defaultServices: PlatformService[] = [
     category: 'observability',
     requiresAuth: true,
     displayOrder: 6
+  },
+  {
+    id: 'sonarqube',
+    name: 'Code Quality & Security',
+    description: 'Static analysis, bugs, vulnerabilities',
+    path: '/sonarqube',
+    icon: 'code-quality',
+    category: 'devsecops',
+    requiresAuth: true,
+    displayOrder: 7
   }
 ];
 
@@ -127,6 +137,7 @@ export function getCategoryName(category: ServiceCategory | string): string {
     developer: 'Developer',
     data: 'Data',
     messaging: 'Messaging',
+    devsecops: 'DevSecOps',
     other: 'Other'
   };
   

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,6 +36,7 @@ export type ServiceCategory =
   | 'developer'
   | 'data'
   | 'messaging'
+  | 'devsecops'
   | 'other';
 
 /**


### PR DESCRIPTION
## Closes #22

## Änderungen

| Datei | Änderung |
|---|---|
| `src/icons.ts` | `code-quality` Icon hinzugefügt (Lupe mit Häkchen) |
| `src/types.ts` | `'devsecops'` zur `ServiceCategory` Union hinzugefügt |
| `src/services.ts` | `devsecops → 'DevSecOps'` in `getCategoryName()` |
| `src/services.ts` | SonarQube in `defaultServices` Fallback-Liste |

## Vorher / Nachher

| | Vorher | Nachher |
|---|---|---|
| Icon | ☐ Box (Fallback) | 🔍 Lupe mit Häkchen |
| Kategorie-Badge | `devsecops` (raw) | `DevSecOps` |
| API-Fallback | SonarQube fehlt | SonarQube sichtbar |

```
✓ npm run build — kein TypeScript-Fehler, Bundle: 17.50 kB
```