### PR TITLE
fix: Explicit 3-row DOM structure for service grid (SonarQube row 2, ArgoCD row 3)

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -334,17 +334,10 @@ body::before {
   gap: var(--spacing-lg);
 }
 
-/* Service Grid - 3 columns */
-.service-grid {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: var(--spacing-lg);
-}
-
 /* Service Card - Square tiles */
 .service-card {
-  aspect-ratio: 1 / 1;
-  min-height: 180px;
+  aspect-ratio: auto;
+  min-height: 140px;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -448,13 +441,33 @@ body::before {
   opacity: 0.7;
 }
 
-/* Hero card — spans full 3-column width, shorter than normal tiles */
-.service-card--hero {
-  grid-column: 1 / -1;
-  aspect-ratio: auto;
+/* Row 1: Hero (Keycloak) */
+.service-row--hero {
+  width: 100%;
+  margin-bottom: var(--spacing-lg);
+}
+
+.service-row--hero .service-card {
+  width: 100%;
   min-height: 120px;
+  aspect-ratio: auto;
   flex-direction: row;
+  justify-content: flex-start;
   gap: var(--spacing-xl);
+  padding: var(--spacing-lg) var(--spacing-xl);
+}
+
+/* Rows 2 & 3: 3-column tile grids */
+.service-row--tiles {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--spacing-lg);
+  margin-bottom: var(--spacing-lg);
+}
+
+.service-row--tiles .service-card {
+  min-height: 140px;
+  aspect-ratio: auto;
 }
 
 /* Footer */
@@ -547,9 +560,9 @@ body::before {
 }
 
 /* Responsive */
-@media (max-width: 900px) {
-  .service-grid {
-    grid-template-columns: repeat(2, 1fr);
+@media (max-width: 768px) {
+  .service-row--tiles {
+    grid-template-columns: 1fr;
   }
 }
 
@@ -557,32 +570,23 @@ body::before {
   .header {
     padding: var(--spacing-sm) var(--spacing-md);
   }
-  
+
   .logo-text {
     display: none;
   }
-  
+
   .main-content {
     padding: var(--spacing-lg) var(--spacing-md);
   }
-  
+
   .welcome h1 {
     font-size: var(--font-size-2xl);
   }
-  
-  .service-grid {
-    grid-template-columns: 1fr;
-  }
-  
-  .service-card {
-    aspect-ratio: auto;
-    min-height: 140px;
-  }
-  
+
   .user-menu {
     padding: var(--spacing-xs);
   }
-  
+
   .username {
     display: none;
   }

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -107,27 +107,25 @@ function renderLoginPrompt(): string {
   `;
 }
 
-/**
- * Render services in a structured 3-row grid layout:
- * Row 1: Keycloak hero tile spanning all 3 columns
- * Row 2: Backstage | Gitea | SonarQube
- * Row 3: ArgoCD | Grafana | Jaeger
- */
 function renderServices(services: PlatformService[], authenticated: boolean): string {
   if (services.length === 0) {
-    return `
-      <section class="services">
-        <div class="service-grid">
-          <p>No services available.</p>
-        </div>
-      </section>
-    `;
+    return `<section class="services"><p>No services available.</p></section>`;
   }
+
+  const hero = services[0];
+  const row2 = services.slice(1, 4);
+  const row3 = services.slice(4, 7);
 
   return `
     <section class="services">
-      <div class="service-grid">
-        ${services.map((service, index) => renderServiceCard(service, authenticated, index === 0)).join('')}
+      <div class="service-row service-row--hero">
+        ${renderServiceCard(hero, authenticated, true)}
+      </div>
+      <div class="service-row service-row--tiles">
+        ${row2.map(s => renderServiceCard(s, authenticated, false)).join('')}
+      </div>
+      <div class="service-row service-row--tiles">
+        ${row3.map(s => renderServiceCard(s, authenticated, false)).join('')}
       </div>
     </section>
   `;


### PR DESCRIPTION
## Summary

Closes #26

Fixes the service grid layout by replacing CSS grid auto-placement with an explicit 3-row DOM structure. Layout is now deterministic regardless of browser/CSS engine behaviour.

## Layout (guaranteed)

```
┌─────────────────────────────────────────────┐
│          Keycloak — Identities & Access      │  Row 1 hero (120px)
└─────────────────────────────────────────────┘
┌─────────────┐ ┌─────────────┐ ┌─────────────┐
│  Backstage  │ │    Gitea    │ │  SonarQube  │  Row 2 (140px each)
└─────────────┘ └─────────────┘ └─────────────┘
┌─────────────┐ ┌─────────────┐ ┌─────────────┐
│   ArgoCD    │ │   Grafana   │ │    Jaeger   │  Row 3 (140px each)
└─────────────┘ └─────────────┘ └─────────────┘
```

## Changes

**`src/ui.ts`** — `renderServices` now renders 3 explicit DOM wrappers:
- `.service-row--hero` → Keycloak (services[0])
- `.service-row--tiles` → Backstage, Gitea, SonarQube (services[1–3])
- `.service-row--tiles` → ArgoCD, Grafana, Jaeger (services[4–6])

**`src/style.css`**:
- Removed `.service-grid` (CSS auto-placement)
- Updated `.service-card`: `aspect-ratio: auto`, `min-height: 140px`
- Added `.service-row--hero .service-card`: full width, 120px, flex-direction: row
- Added `.service-row--tiles`: 3-column grid
- Responsive: ≤768px → single column