### PR TITLE
feat(opencost): add Cloud Costs tile to landing page

### DIFF
--- a/public/services.json
+++ b/public/services.json
@@ -48,5 +48,15 @@
     "category": "monitoring",
     "requiresAuth": true,
     "displayOrder": 5
+  },
+  {
+    "id": "opencost",
+    "name": "Cloud Costs",
+    "description": "Kubernetes cost monitoring & allocation",
+    "path": "/opencost",
+    "icon": "chart",
+    "category": "monitoring",
+    "requiresAuth": true,
+    "displayOrder": 8
   }
 ]


### PR DESCRIPTION
## Summary

Adds the OpenCost **Cloud Costs** tile to `public/services.json` (dev fallback), in sync with the `services-configmap.yaml` update in digiorg/core PR #226.

## Changes

- `public/services.json`: New entry `opencost` — "Cloud Costs", path `/opencost`, icon `chart`, category `monitoring`, displayOrder 8, requiresAuth true

## Notes

The runtime ConfigMap (`platform/base/landingpage/services-configmap.yaml` in digiorg/core) was already updated as part of the OpenCost integration (core PR #226). This PR keeps the dev fallback file in sync.

Related: digiorg/core#224 | digiorg/core PR #226