### PR TITLE
fix(opencost): dynamic tile grid + add missing services to fallback

### DIFF
--- a/public/services.json
+++ b/public/services.json
@@ -50,6 +50,26 @@
     "displayOrder": 5
   },
   {
+    "id": "jaeger",
+    "name": "Tracing & Observing",
+    "description": "Distributed Tracing & Observing",
+    "path": "/jaeger",
+    "icon": "tracing",
+    "category": "observability",
+    "requiresAuth": true,
+    "displayOrder": 6
+  },
+  {
+    "id": "sonarqube",
+    "name": "Code Quality & Security",
+    "description": "Static analysis, bugs, vulnerabilities",
+    "path": "/sonarqube",
+    "icon": "code-quality",
+    "category": "devsecops",
+    "requiresAuth": true,
+    "displayOrder": 7
+  },
+  {
     "id": "opencost",
     "name": "Cloud Costs",
     "description": "Kubernetes cost monitoring & allocation",

--- a/src/services.ts
+++ b/src/services.ts
@@ -76,6 +76,16 @@ const defaultServices: PlatformService[] = [
     category: 'observability',
     requiresAuth: true,
     displayOrder: 7
+  },
+  {
+    id: 'opencost',
+    name: 'Cloud Costs',
+    description: 'Kubernetes cost monitoring & allocation',
+    path: '/opencost',
+    icon: 'chart',
+    category: 'monitoring',
+    requiresAuth: true,
+    displayOrder: 8
   }
 ];
 

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -113,20 +113,24 @@ function renderServices(services: PlatformService[], authenticated: boolean): st
   }
 
   const hero = services[0];
-  const row2 = services.slice(1, 4);
-  const row3 = services.slice(4, 7);
+  const remaining = services.slice(1);
+
+  // Chunk remaining services into rows of 3 — supports any number of services dynamically
+  const rows: PlatformService[][] = [];
+  for (let i = 0; i < remaining.length; i += 3) {
+    rows.push(remaining.slice(i, i + 3));
+  }
 
   return `
     <section class="services">
       <div class="service-row service-row--hero">
         ${renderServiceCard(hero, authenticated, true)}
       </div>
-      <div class="service-row service-row--tiles">
-        ${row2.map(s => renderServiceCard(s, authenticated, false)).join('')}
-      </div>
-      <div class="service-row service-row--tiles">
-        ${row3.map(s => renderServiceCard(s, authenticated, false)).join('')}
-      </div>
+      ${rows.map(row => `
+        <div class="service-row service-row--tiles">
+          ${row.map(s => renderServiceCard(s, authenticated, false)).join('')}
+        </div>
+      `).join('')}
     </section>
   `;
 }


### PR DESCRIPTION
## Summary

Fixes the missing OpenCost tile on the landing page (Bug 2 of digiorg/core#229).

## Root Cause

`renderServices()` in `src/ui.ts` had a hardcoded 3-row layout for exactly 7 services:
`services.slice(4, 7)` — any service at index ≥ 7 was silently dropped.
OpenCost (displayOrder=8) sits at index 7 → never rendered.

## Fix

### `src/ui.ts`
Replace hardcoded `slice(4, 7)` with dynamic row chunking (groups of 3).
Handles any number of platform services without code changes.

### `src/services.ts`
Add `opencost` to `defaultServices` fallback array.

### `public/services.json`
Add missing `jaeger` (displayOrder 6) and `sonarqube` (displayOrder 7) entries
to keep the dev fallback in sync with the platform ConfigMap.

## Changes

| File | Change |
|------|--------|
| `src/ui.ts` | Dynamic row chunking replaces `slice(4, 7)` |
| `src/services.ts` | Add opencost to defaultServices fallback |
| `public/services.json` | Add jaeger + sonarqube; full 8-service dev fallback |

## Acceptance Criteria

- [ ] Landing page shows 8 tiles (keycloak hero + 7 in 3+3+1 rows)
- [ ] Cloud Costs tile visible (authenticated and unauthenticated view)
- [ ] Adding a 9th service in the future renders in a new row automatically

Fixes digiorg/core#229 (Bug 2) | Related: digiorg/core#224