### PR TITLE
feat(landingpage): add Harbor Registry tile

### DIFF
--- a/public/services.json
+++ b/public/services.json
@@ -78,5 +78,15 @@
     "category": "monitoring",
     "requiresAuth": true,
     "displayOrder": 8
+  },
+  {
+    "id": "harbor",
+    "name": "Harbor Registry",
+    "description": "OCI container registry with vulnerability scanning",
+    "path": "/harbor",
+    "icon": "server",
+    "category": "infrastructure",
+    "requiresAuth": true,
+    "displayOrder": 9
   }
 ]


### PR DESCRIPTION
## Summary

Adds the Harbor Registry service tile to the landing page dev fallback (`public/services.json`).

## Changes

- `public/services.json`: Add `harbor` tile (displayOrder 9, category `infrastructure`)

## Context

The runtime ConfigMap was updated in digiorg/core#247. This PR syncs the dev fallback so local development without the Kubernetes ConfigMap also shows the Harbor tile.

Relates to digiorg/core#225