### PR TITLE
fix(landingpage): add Harbor to defaultServices, infrastructure category, and server icon

### DIFF
--- a/src/icons.ts
+++ b/src/icons.ts
@@ -114,6 +114,14 @@ const icons: Record<string, string> = {
     <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>
   </svg>`,
   
+  // Container Registry
+  server: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <rect x="2" y="2" width="20" height="8" rx="2" ry="2"/>
+    <rect x="2" y="14" width="20" height="8" rx="2" ry="2"/>
+    <line x1="6" y1="6" x2="6.01" y2="6"/>
+    <line x1="6" y1="18" x2="6.01" y2="18"/>
+  </svg>`,
+
   // Generic
   box: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
     <path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/>

--- a/src/services.ts
+++ b/src/services.ts
@@ -86,6 +86,16 @@ const defaultServices: PlatformService[] = [
     category: 'monitoring',
     requiresAuth: true,
     displayOrder: 8
+  },
+  {
+    id: 'harbor',
+    name: 'Harbor Registry',
+    description: 'OCI container registry with vulnerability scanning',
+    path: '/harbor',
+    icon: 'server',
+    category: 'infrastructure',
+    requiresAuth: true,
+    displayOrder: 9
   }
 ];
 
@@ -148,6 +158,7 @@ export function getCategoryName(category: ServiceCategory | string): string {
     data: 'Data',
     messaging: 'Messaging',
     devsecops: 'DevSecOps',
+    infrastructure: 'Infrastructure',
     other: 'Other'
   };
   

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,6 +37,7 @@ export type ServiceCategory =
   | 'data'
   | 'messaging'
   | 'devsecops'
+  | 'infrastructure'
   | 'other';
 
 /**


### PR DESCRIPTION
## Summary

Three small fixes to make the Harbor tile work correctly in the landing page.

## Changes

### `src/services.ts`
- Add Harbor Registry to `defaultServices` (displayOrder 9, category `infrastructure`)
- Add `infrastructure: 'Infrastructure'` to `getCategoryName()`

### `src/types.ts`
- Add `'infrastructure'` to `ServiceCategory` union type

### `src/icons.ts`
- Add `server` SVG icon (two server rack rectangles — fitting for a container registry)

## Context

The Harbor tile was missing from `defaultServices`, meaning even if `/api/services` fails for any reason, Harbor would never appear as a fallback. The primary routing fix is in digiorg/core#251 (narrowing `/api/(.*)` → `/api/v2.0/(.*)`).

Fixes digiorg/core-landingpage#31
Related: digiorg/core#225